### PR TITLE
feat: a closed variable can never have no options

### DIFF
--- a/src/ClosedVariableInterface.php
+++ b/src/ClosedVariableInterface.php
@@ -9,7 +9,7 @@ namespace Collecthor\DataInterfaces;
 interface ClosedVariableInterface extends VariableInterface
 {
     /**
-     * @return ValueOptionInterface[] A list of value options
+     * @return non-empty-list<ValueOptionInterface> A list of value options
      */
     public function getValueOptions(): array;
 


### PR DESCRIPTION
While in the surveyjs json configuration, a question can have no options, our variables can never have no options. Therefore, make the return type of getValueOptions a non-empty-list